### PR TITLE
Fill Boss HP immediately.

### DIFF
--- a/hack.asm
+++ b/hack.asm
@@ -137,6 +137,12 @@ incbin "numbersprites.bin", 9 * $10, $10
 
 {loadpc}
 
+// Boss HP fills immediately
+{savepc}
+	{reorg $35, $A866}
+	lda.b #$1C
+	sta.b $BF
+{loadpc}
 
 // Hook the reset sequence to load our code from CHR-ROM to PRG-RAM.
 {savepc}


### PR DESCRIPTION
Skips the wait for the boss HP meter to fill.

Music should ideally skip a few seconds ahead of well to stay in sync, but I haven't dug into the sound yet to handle that yet.